### PR TITLE
Add Missing libdouble-conversion-dev dependency on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd ptyqt-build
 
 ### Build on Ubuntu
 ```sh
-sudo apt-get install qtbase5-dev cmake libqt5websockets5-dev
+sudo apt-get install qtbase5-dev cmake libqt5websockets5-dev libdouble-conversion-dev
 git clone https://github.com/kafeg/ptyqt.git ptyqt
 mkdir ptyqt-build
 cd ptyqt-build


### PR DESCRIPTION
This patch adds the missing libdouble-conversion-dev dependency for Ubuntu. As trying to build without it will result in the following error from CMake.

CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
DBLCONV_LIBRARIES
    linked by target "ptyqt" in directory /media/tom/T7/git/linux/ptyqt/core